### PR TITLE
Fix mistake in simcomp allocation

### DIFF
--- a/src/simulation_components/simcomp_executor.f90
+++ b/src/simulation_components/simcomp_executor.f90
@@ -170,7 +170,7 @@ contains
        if (.not. is_user) call neko_log%message('- ' // trim(comp_type))
 
        call simulation_component_factory(this%simcomps(i)%simcomp, &
-                                         comp_subdict, case)
+            comp_subdict, case)
     end do
 
     if (has_user) then
@@ -225,7 +225,7 @@ contains
     ! If no empty position was found, append to the end
     if (position == 0) then
        call move_alloc(this%simcomps, tmp_simcomps)
-       allocate(this%simcomps(position))
+       allocate(this%simcomps(this%n_simcomps + 1))
 
        if (allocated(tmp_simcomps)) then
           do i = 1, this%n_simcomps
@@ -279,7 +279,7 @@ contains
        end do
        if (order_found .and. .not. previous_found) then
           call neko_error("Simulation component order must be contiguous &
-            &starting at 1.")
+               &starting at 1.")
        end if
        previous_found = order_found
     end do


### PR DESCRIPTION
The `simcomp_executor_add` subroutine now correctly allocates memory for the `simcomps` array. 